### PR TITLE
Report du zoom "à la loupe" des taxinomes vers geodiv

### DIFF
--- a/geodiversite/inc-insert-head.html
+++ b/geodiversite/inc-insert-head.html
@@ -1,2 +1,3 @@
 [<script src="(#CHEMIN{javascript/geol.js})" type="text/javascript"></script>]
+[<script src="(#CHEMIN{javascript/jquery.zoom.js})" type="text/javascript"></script>]
 [(#MODELE{favicon})]

--- a/geodiversite/inclure/media_doc.html
+++ b/geodiversite/inclure/media_doc.html
@@ -65,11 +65,38 @@
 ]
 
 <script type="text/javascript">
-(function($) {
-	$('#supprimer_doc').click(function(){
-		return confirm("<:geol:doc_supprimer_confirm|texte_script:>");
+<!--
+(function($){
+	$(function(){
+		$('#supprimer_doc').click(function(){
+			return confirm("<:geol:doc_supprimer_confirm|texte_script:>");
+		});
+		[(#LARGEUR|>{#ENV{largeur}}|oui)
+		var clicked = false;
+		$('.actions_doc .zoom').attr('type','').attr('title','<:taxinomes:aide_zoom|texte_script:>').on('click', function(){
+			if (clicked) {
+				clicked = false;
+				$('.zoomImg').remove();
+			} else {
+				clicked = true;
+				$('.image_legendes').animateLoading().zoom({
+					url: '[(#FICHIER|url_absolue)]',
+					callback: function(){
+						$('.image_legendes').endLoading(true);
+					}
+				});
+			}
+			return false;
+		});
+		$('.image_legendes').click(function(){
+			if (clicked) {
+				clicked = false;
+				$('.zoomImg').remove();
+			}
+		});]
 	});
 })(jQuery);
+-->
 </script>
 
 [(#REM) Sinon : document normal ]

--- a/geodiversite/javascript/jquery.zoom.js
+++ b/geodiversite/javascript/jquery.zoom.js
@@ -1,0 +1,173 @@
+/*
+	jQuery Zoom v1.7.1 - 2013-03-12
+	(c) 2013 Jack Moore - jacklmoore.com/zoom
+	license: http://www.opensource.org/licenses/mit-license.php
+*/
+(function ($) {
+	var defaults = {
+		url: false,
+		callback: false,
+		target: false,
+		duration: 120,
+		on: 'mouseover' // other options: 'grab', 'click', 'toggle'
+	};
+
+	// Core Zoom Logic, independent of event listeners.
+	$.zoom = function(target, source, img) {
+		var outerWidth,
+			outerHeight,
+			xRatio,
+			yRatio,
+			offset,
+			position = $(target).css('position');
+
+		// The parent element needs positioning so that the zoomed element can be correctly positioned within.
+		$(target).css({
+			position: /(absolute|fixed)/.test() ? position : 'relative',
+			overflow: 'hidden'
+		});
+
+		$(img)
+			.addClass('zoomImg')
+			.css({
+				position: 'absolute',
+				top: 0,
+				left: 0,
+				opacity: 0,
+				width: img.width,
+				height: img.height,
+				border: 'none',
+				maxWidth: 'none'
+			})
+			.appendTo(target);
+
+		return {
+			init: function() {
+				outerWidth = $(target).outerWidth();
+				outerHeight = $(target).outerHeight();
+				xRatio = (img.width - outerWidth) / $(source).outerWidth();
+				yRatio = (img.height - outerHeight) / $(source).outerHeight();
+				offset = $(source).offset();
+			},
+			move: function (e) {
+				var left = (e.pageX - offset.left),
+					top = (e.pageY - offset.top);
+
+				top = Math.max(Math.min(top, outerHeight), 0);
+				left = Math.max(Math.min(left, outerWidth), 0);
+
+				img.style.left = (left * -xRatio) + 'px';
+				img.style.top = (top * -yRatio) + 'px';
+			}
+		};
+	};
+
+	$.fn.zoom = function (options) {
+		return this.each(function () {
+			var
+			settings = $.extend({}, defaults, options || {}),
+			//target will display the zoomed iamge
+			target = settings.target || this,
+			//source will provide zoom location info (thumbnail)
+			source = this,
+			img = new Image(),
+			$img = $(img),
+			mousemove = 'mousemove',
+			clicked = false;
+
+			// If a url wasn't specified, look for an image element.
+			if (!settings.url) {
+				settings.url = $(source).find('img').attr('src');
+				if (!settings.url) {
+					return;
+				}
+			}
+
+			img.onload = function () {
+				var zoom = $.zoom(target, source, img);
+
+				function start(e) {
+					zoom.init();
+					zoom.move(e);
+
+					// Skip the fade-in for IE8 and lower since it chokes on fading-in
+					// and changing position based on mousemovement at the same time.
+					$img.stop()
+					.fadeTo($.support.opacity ? settings.duration : 0, 1);
+				}
+
+				function stop() {
+					$img.stop()
+					.fadeTo(settings.duration, 0);
+				}
+
+				if (settings.on === 'grab') {
+					$(source).on('mousedown',
+						function (e) {
+							$(document).one('mouseup',
+								function () {
+									stop();
+
+									$(document).off(mousemove, zoom.move);
+								}
+							);
+
+							start(e);
+
+							$(document).on(mousemove, zoom.move);
+
+							e.preventDefault();
+						}
+					);
+				} else if (settings.on === 'click') {
+					$(source).on('click',
+						function (e) {
+							if (clicked) {
+								// bubble the event up to the document to trigger the unbind.
+								return;
+							} else {
+								clicked = true;
+								start(e);
+								$(document).on(mousemove, zoom.move);
+								$(document).one('click',
+									function () {
+										stop();
+										clicked = false;
+										$(document).off(mousemove, zoom.move);
+									}
+								);
+								return false;
+							}
+						}
+					);
+				} else if (settings.on === 'toggle') {
+					$(source).on('click',
+						function (e) {
+							if (clicked) {
+								stop();
+							} else {
+								start(e);
+							}
+							clicked = !clicked;
+						}
+					);
+				} else {
+					zoom.init(); // Pre-emptively call init because IE7 will fire the mousemove handler before the hover handler.
+
+					$(source)
+						.on('mouseenter', start)
+						.on('mouseleave', stop)
+						.on(mousemove, zoom.move);
+				}
+
+				if ($.isFunction(settings.callback)) {
+					settings.callback.call(img);
+				}
+			};
+
+			img.src = settings.url;
+		});
+	};
+
+	$.fn.zoom.defaults = defaults;
+}(window.jQuery));


### PR DESCRIPTION
Le zoom des taxniomes fonctionne bien, exemple ici : 

http://www.lestaxinomes.org/media9774

On pourrait l'intégrer dans geodiv, mais il faudra peut être modifier le comportement en place sur les taxinomes car pour l'instant on se déplace dans l'image en la survolant (hover) ce qui risque de poser problème sur les périphériques mobiles.

Le script utilisé permet de se déplacer lors du "drag" au lieu du "hover" : 

http://www.jacklmoore.com/zoom/

Voici ce que ça donnerait comme comportement  : Clic sur le bouton de zoom, puis cliqué+glissé pour se déplacer dans l'image. Le zoom s'arrête quand on relache le clic... Bref c'est pas le top :p
